### PR TITLE
Updated foundry link to point to the right place

### DIFF
--- a/Downloading-Foundry-VTT.md
+++ b/Downloading-Foundry-VTT.md
@@ -1,2 +1,2 @@
-Foundry is available via your user profile page on [https://foundryvtt.com](foundryvtt.com).  Your user profile page is available by clicking your username on the top right of any page.  On this page, click on Purchased Licenses under your avatar and username.  You will find a list of download links for Windows, MacOS, and Linux under your licenses.
+Foundry is available via your user profile page on [https://foundryvtt.com](https://foundryvtt.com).  Your user profile page is available by clicking your username on the top right of any page.  On this page, click on Purchased Licenses under your avatar and username.  You will find a list of download links for Windows, MacOS, and Linux under your licenses.
 


### PR DESCRIPTION
Before, the link was relative, now it should be absolute